### PR TITLE
fix: Correct React Hook call order in AdminDashboard

### DIFF
--- a/src/pages/admin/Dashboard.tsx
+++ b/src/pages/admin/Dashboard.tsx
@@ -18,6 +18,7 @@ const AdminDashboard: React.FC = () => {
   const [showViewModal, setShowViewModal] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
   const [selectedEntry, setSelectedEntry] = useState<DevotionalEntry | null>(null);
+  const [activeSection, setActiveSection] = useState<string>('dld'); // Moved here
 
   useEffect(() => {
     if (isLoggedIn) {
@@ -101,8 +102,6 @@ const AdminDashboard: React.FC = () => {
       </div>
     );
   }
-
-  const [activeSection, setActiveSection] = useState<string>('dld'); // Default to DLD management
 
   // Main Dashboard Content
   return (


### PR DESCRIPTION
Moved the useState call for 'activeSection' to the top level of the AdminDashboard component. This ensures that Hooks are called in the same order on every render, resolving a "Rendered more hooks than during the previous render" error and adhering to the Rules of Hooks.