### PR TITLE
feat: Configure API base URL and CORS for DLD admin

### DIFF
--- a/php/delete_dld_entry.php
+++ b/php/delete_dld_entry.php
@@ -1,4 +1,18 @@
 <?php
+
+$allowedOrigins = ['https://dev.lightlifechurch.com', 'https://lightlifechurch.com'];
+if (isset($_SERVER['HTTP_ORIGIN']) && in_array($_SERVER['HTTP_ORIGIN'], $allowedOrigins)) {
+    header('Access-Control-Allow-Origin: ' . $_SERVER['HTTP_ORIGIN']);
+}
+header('Access-Control-Allow-Methods: GET, POST, OPTIONS'); // Added POST
+header('Access-Control-Allow-Headers: Content-Type');
+// header('Access-Control-Allow-Credentials: true');
+
+if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
+    http_response_code(200);
+    exit;
+}
+
 header('Content-Type: application/json');
 
 require_once 'db_connect.php'; // Establishes $conn

--- a/php/get_dld_entries.php
+++ b/php/get_dld_entries.php
@@ -1,4 +1,18 @@
 <?php
+
+$allowedOrigins = ['https://dev.lightlifechurch.com', 'https://lightlifechurch.com'];
+if (isset($_SERVER['HTTP_ORIGIN']) && in_array($_SERVER['HTTP_ORIGIN'], $allowedOrigins)) {
+    header('Access-Control-Allow-Origin: ' . $_SERVER['HTTP_ORIGIN']);
+}
+header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type');
+// header('Access-Control-Allow-Credentials: true'); // If you need cookies/sessions
+
+if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
+    http_response_code(200);
+    exit;
+}
+
 header('Content-Type: application/json');
 require_once 'db_connect.php'; // Establishes $conn
 

--- a/php/submit_dld_form.php
+++ b/php/submit_dld_form.php
@@ -1,4 +1,18 @@
 <?php
+
+$allowedOrigins = ['https://dev.lightlifechurch.com', 'https://lightlifechurch.com'];
+if (isset($_SERVER['HTTP_ORIGIN']) && in_array($_SERVER['HTTP_ORIGIN'], $allowedOrigins)) {
+    header('Access-Control-Allow-Origin: ' . $_SERVER['HTTP_ORIGIN']);
+}
+header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type');
+// header('Access-Control-Allow-Credentials: true');
+
+if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
+    http_response_code(200);
+    exit;
+}
+
 header('Content-Type: application/json'); // We'll be sending JSON responses
 
 require_once 'db_connect.php'; // Establishes $conn

--- a/php/update_dld_entry.php
+++ b/php/update_dld_entry.php
@@ -1,4 +1,18 @@
 <?php
+
+$allowedOrigins = ['https://dev.lightlifechurch.com', 'https://lightlifechurch.com'];
+if (isset($_SERVER['HTTP_ORIGIN']) && in_array($_SERVER['HTTP_ORIGIN'], $allowedOrigins)) {
+    header('Access-Control-Allow-Origin: ' . $_SERVER['HTTP_ORIGIN']);
+}
+header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type');
+// header('Access-Control-Allow-Credentials: true');
+
+if ($_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
+    http_response_code(200);
+    exit;
+}
+
 header('Content-Type: application/json');
 
 require_once 'db_connect.php'; // Establishes $conn

--- a/src/components/admin/CreateEntryModal.tsx
+++ b/src/components/admin/CreateEntryModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { DevotionalEntry } from '../../types';
+import { API_BASE_URL } from '../../config'; // Import API_BASE_URL
 
 interface CreateEntryModalProps {
   onClose: () => void;
@@ -41,7 +42,7 @@ const CreateEntryModal: React.FC<CreateEntryModalProps> = ({ onClose, onSave }) 
     formData.append('bibleReadingPlan', bibleReadingPlan);
 
     try {
-      const response = await fetch('/php/submit_dld_form.php', { // Adjusted path
+      const response = await fetch(`${API_BASE_URL}/submit_dld_form.php`, {
         method: 'POST',
         body: formData,
       });

--- a/src/components/admin/EditEntryModal.tsx
+++ b/src/components/admin/EditEntryModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { DevotionalEntry } from '../../types';
+import { API_BASE_URL } from '../../config'; // Import API_BASE_URL
 
 interface EditEntryModalProps {
   entry: DevotionalEntry | null;
@@ -79,7 +80,7 @@ const EditEntryModal: React.FC<EditEntryModalProps> = ({ entry, onClose, onSave 
     formData.append('bibleReadingPlan', bibleReadingPlan);
 
     try {
-      const response = await fetch('/php/update_dld_entry.php', {
+      const response = await fetch(`${API_BASE_URL}/update_dld_entry.php`, {
         method: 'POST',
         body: formData,
       });

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,1 @@
+export const API_BASE_URL = 'https://lightlifechurch.com/php/new';

--- a/src/pages/admin/Dashboard.tsx
+++ b/src/pages/admin/Dashboard.tsx
@@ -4,7 +4,8 @@ import { DevotionalEntry } from '../../types';
 import CreateEntryModal from '../../components/admin/CreateEntryModal';
 import ViewEntryModal from '../../components/admin/ViewEntryModal';
 import EditEntryModal from '../../components/admin/EditEntryModal';
-import DldManagement from '../../components/admin/DldManagement'; // Import DLD Management component
+import DldManagement from '../../components/admin/DldManagement';
+import { API_BASE_URL } from '../../config'; // Import API_BASE_URL
 
 
 const AdminDashboard: React.FC = () => {
@@ -33,7 +34,7 @@ const AdminDashboard: React.FC = () => {
         setIsLoadingDevotionals(true);
         setFetchDevotionalsError(null);
         try {
-          const response = await fetch('/php/get_dld_entries.php');
+          const response = await fetch(`${API_BASE_URL}/get_dld_entries.php`);
           if (!response.ok) {
             const errorData = await response.json().catch(() => ({ message: 'Failed to fetch devotionals. Server error.' }));
             throw new Error(errorData.message || `Server error: ${response.status}`);
@@ -86,7 +87,7 @@ const AdminDashboard: React.FC = () => {
         const formData = new FormData();
         formData.append('id', entryId);
 
-        const response = await fetch('/php/delete_dld_entry.php', {
+        const response = await fetch(`${API_BASE_URL}/delete_dld_entry.php`, {
           method: 'POST',
           body: formData,
         });


### PR DESCRIPTION
- Introduced `src/config.ts` to define `API_BASE_URL` for the PHP backend.
- Updated all frontend fetch calls in DLD admin components to use the centralized `API_BASE_URL`.
- Implemented dynamic CORS (Cross-Origin Resource Sharing) handling in all PHP endpoint scripts.
- PHP scripts now check `$_SERVER['HTTP_ORIGIN']` and set `Access-Control-Allow-Origin` for allowed domains (`dev.lightlifechurch.com` and `lightlifechurch.com`).
- Added handling for preflight OPTIONS requests in PHP scripts.